### PR TITLE
Set header replace flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ make test
 Changelog
 ---------
 
+1.2.0
+
+* Added $replace flag to SAI\Response::setHeader (default true as in PHP header).
+
 1.1.0
 
 * Added SAI\Response::setResponseCode.

--- a/lib/Mock/Response.php
+++ b/lib/Mock/Response.php
@@ -6,8 +6,16 @@ class Response implements \SAI\Response {
   public $headers = array(), $cookies = array(), $cookies_deleted = array();
   public $output = '', $response_code = 200;
 
-  public function setHeader($name, $value) {
-    $this->headers[strtolower($name)] = $value;
+  public function setHeader($name, $value, $replace = true) {
+    // Imitating the format you get from http_parse_headers
+    $key = strtolower($name);
+    if ($replace === false && isset($this->headers[$key])) {
+      if (!is_array($this->headers[$key])) {
+        $this->headers[$key] = array($this->headers[$key]);
+      }
+      $this->headers[$key][] = $value;
+    }
+    else $this->headers[$key] = $value;
   }
 
   public function setResponseCode($code) {

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -16,7 +16,7 @@ interface Response {
    * @param string $name
    * @param string $value
    */
-  public function setHeader($name, $value);
+  public function setHeader($name, $value, $replace = true);
 
   /**
    * Sets HTTP response code.

--- a/lib/System/Response.php
+++ b/lib/System/Response.php
@@ -9,8 +9,8 @@ namespace SAI\System;
  * access.
  */
 class Response implements \SAI\Response {
-  public function setHeader($name, $value) {
-    header("$name: $value");
+  public function setHeader($name, $value, $replace = true) {
+    header("$name: $value", $replace);
   }
 
   public function setResponseCode($code) {

--- a/tests/MockResponseTest.php
+++ b/tests/MockResponseTest.php
@@ -48,4 +48,17 @@ class MockResponseTest extends PHPUnit_Framework_TestCase {
       $this->response_mock->output
     );
   }
+
+  public function testMultipleHeaders() {
+    $this->response_mock->setHeader('set-cookie', 'foo=bar', false);
+    $this->response_mock->setHeader('set-cookie', 'baz=qux', false);
+
+    $this->assertEquals(array('foo=bar', 'baz=qux'), $this->response_mock->headers['set-cookie']);
+  }
+
+  public function testHeaderReplaceWithOnlyOne() {
+    $this->response_mock->setHeader('set-cookie', 'foo=bar', false);
+
+    $this->assertEquals('foo=bar', $this->response_mock->headers['set-cookie']);
+  }
 }


### PR DESCRIPTION
A few headers can be present multiple times in a response, like set-cookie.  Even if there is a setCookie-method, you can use setHeader, and need to be able to NOT replace it (as is PHP's header-functions default behaviour).

This adds a $replace-flag to Response->setHeader.
